### PR TITLE
Keep `sameAs` triple in output file if it already existed before

### DIFF
--- a/lib/pipeline-mirroring.js
+++ b/lib/pipeline-mirroring.js
@@ -121,10 +121,15 @@ async function renameUri(oldUri) {
     }
   `);
   if (queryResult.results.bindings && queryResult.results.bindings[0]) {
-    return { sameAsTriple: undefined, newUri: queryResult.results.bindings[0].newURI.value };
+    const newUri = queryResult.results.bindings[0].newURI.value;
+    const sameAsTriple = {
+      subject: { value: newUri, type: 'uri' },
+      predicate: { value: 'http://www.w3.org/2002/07/owl#sameAs', type: 'uri' },
+      object: { value: oldUri, type: 'uri' }
+    };
+    return { sameAsTriple, newUri };
   } else {
     const newUri = `${RENAME_DOMAIN}${uuid()}`;
-
     const sameAsTriple = {
       subject: { value: newUri, type: 'uri' },
       predicate: { value: 'http://www.w3.org/2002/07/owl#sameAs', type: 'uri' },


### PR DESCRIPTION
If it already existed, it was previously not included in the output file, which caused the diff service to think the `sameAs` triples are actually removed, which is not the case. This PR add it to the output file again.

The previous behaviour never caused issues because updates (deletes and inserts) to documents where never really considered.