### PR TITLE
Use N-Triples formatting for data in SPARQL queries

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,7 +13,7 @@ import * as cts from '../constants';
  * prefixes.)
  */
 export function storeToSparql(store) {
-  return storeToString(store, false);
+  return storeToString(store, true);
 }
 
 /**
@@ -28,7 +28,7 @@ export function storeToSparql(store) {
  * prefixes at the top to make the file more human readable.)
  */
 export function storeToTtl(store) {
-  return storeToString(store, true);
+  return storeToString(store, false);
 }
 
 /**
@@ -37,14 +37,22 @@ export function storeToTtl(store) {
  * @function
  * @param {N3.Store|Iterable} store - A collection (N3.Store or Array, or
  * something else that can iterated on) that contains RDF.js quads.
- * @param {Boolean} [usePrefixes = false] - If true, the result will contain
- * prefix definitions at the top of the file that will be used throughout the
- * file.
+ * @param {Boolean} [forSparql = true] - If true, the result will be formatted
+ * in N-Triples syntax (without prefixes) so it can be used inside a SPARQL
+ * query. If false, the result will contain prefix definitions at the top of
+ * the file that will be used throughout the file and will be formatted in
+ * more dense Turtle syntax.
+ *
+ * **NOTE:** realistically, the difference between N-Triples and Turtle syntax
+ * is not big. Some datatypes are less explicit in Turtle, such as booleans,
+ * which causes mu-authorization to fail.
  */
-function storeToString(store, usePrefixes = false) {
+function storeToString(store, forSparql = true) {
   // Use the WRITER_PREFIXES, there is much more in them than what is needed
   // for the SPARQL queries.
-  const options = usePrefixes ? { prefixes: cts.WRITER_PREFIXES } : {};
+  const options = forSparql
+    ? { format: 'N-Triples' }
+    : { format: 'Turtle', prefixes: cts.WRITER_PREFIXES };
   const writer = new N3.Writer(options);
   store.forEach((q) => writer.addQuad(q.subject, q.predicate, q.object));
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Fixing a important problem with formatting data that caused queries to fail and keep retrying for a long time. Even though technically (I think) Turtle formatting can be used directly in SPARQL queries, mu-authorization seems to have problems with certain implicit datatypes. Using N-Triples, these are more explicit now.

**How to test?**

Prepare an RDFa document with booleans and other different datatypes and try to harvest it with the `app-lblod-harvester`. The version of this service without the fix will find some triples that keep failing multiple times. With this fix, the data should flow through quickly.