### PR TITLE
Add harvesting provenance

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ import { run as runMirrorPipeline } from './lib/pipeline-mirroring';
 import { run as runPublishPipeline } from './lib/pipeline-publishing';
 import { run as runAddUUIDs } from './lib/pipeline-add-uuids';
 import { run as runExecuteDiffDeletesPipeline } from './lib/pipeline-execute-diff-deletes';
+import { run as runAddHarvestingTag } from './lib/pipeline-add-harvesting-tag';
 import { Lock } from 'async-await-mutex-lock';
 const { namedNode } = N3.DataFactory;
 
@@ -126,6 +127,9 @@ async function processTask(term) {
         break;
       case cts.TASK_HARVESTING_ADD_UUIDS.value:
         await runAddUUIDs(task);
+        break;
+      case cts.TASK_HARVESTING_ADD_TAG.value:
+        await runAddHarvestingTag(task);
         break;
       case cts.TASK_PUBLISH_HARVESTED_TRIPLES.value:
         await runPublishPipeline(task, false);

--- a/constants.js
+++ b/constants.js
@@ -164,6 +164,7 @@ export const TASK_PUBLISH_HARVESTED_TRIPLES = NAMESPACES.tasko`publishHarvestedT
 export const TASK_PUBLISH_HARVESTED_TRIPLES_WITH_DELETES = NAMESPACES.tasko`publishHarvestedTriplesWithDeletes`;
 export const TASK_EXECUTE_DIFF_DELETES = NAMESPACES.tasko`execute-diff-deletes`;
 export const TASK_HARVESTING_ADD_UUIDS = NAMESPACES.tasko`add-uuids`;
+export const TASK_HARVESTING_ADD_TAG = NAMESPACES.tasko`add-harvesting-tag`;
 
 // Environment variables
 

--- a/constants.js
+++ b/constants.js
@@ -26,6 +26,7 @@ const PREFIXES = {
   dbpedia: 'http://dbpedia.org/ontology/',
   jobstat: 'http://redpencil.data.gift/id/concept/JobStatus/',
   tasko: 'http://lblod.data.gift/id/jobs/concept/TaskOperation/',
+  app: 'http://lblod.data.gift/id/app/',
 };
 
 /**

--- a/lib/pipeline-add-harvesting-tag.js
+++ b/lib/pipeline-add-harvesting-tag.js
@@ -1,0 +1,71 @@
+import * as mu from 'mu';
+import * as N3 from 'n3';
+import * as cts from '../constants';
+import * as file from './file-helpers';
+import * as tsk from './task';
+import * as grph from './graph';
+import * as uti from './utils';
+import { NAMESPACES as ns } from '../constants';
+import { BASES as bs } from '../constants';
+const { literal } = N3.DataFactory;
+
+/**
+ * Run the pipeline for adding a harvesting tag, which is just a triple that
+ * indicates that subject originates from harvesting. It loads triples from the
+ * triplestore or from files depending on the way the inputContainer is set up
+ * and adds triple for every subject. If one already exists, the data is added
+ * to the resultsContainer. It also updates the task along the process.
+ *
+ * @public
+ * @async
+ * @function
+ * @param {NamedNode} task - Represents the task for wich to start the process.
+ * @returns {undefined} Nothing
+ */
+export async function run(task) {
+  try {
+    await tsk.updateTaskStatus(task, cts.STATUS_BUSY);
+
+    const tripleStore = await grph.getTriples(task);
+    const complementedTripleStore = await addHarvestingTag(tripleStore);
+    const complementedTripleString = await uti.storeToTtl(
+      complementedTripleStore
+    );
+    const fileContainer = {
+      id: literal(mu.uuid()),
+      node: bs.dataContainer(task.id.value),
+    };
+    const mirroredFile = await file.writeTtlFile(
+      task.graph,
+      complementedTripleString,
+      'complemented-triples.ttl'
+    );
+    await tsk.appendTaskResultFile(task, fileContainer, mirroredFile);
+    const graphContainer = { id: literal(mu.uuid()) };
+    graphContainer.node = bs.dataContainer(graphContainer.id.value);
+    await grph.appendTaskResultGraph(task, graphContainer, fileContainer.node);
+    await tsk.updateTaskStatus(task, cts.STATUS_SUCCESS);
+  } catch (err) {
+    console.error(err);
+    await tsk.appendTaskError(task, err.message);
+    await tsk.updateTaskStatus(task, cts.STATUS_FAILED);
+  }
+}
+
+/**
+ * Collects all subjects from the store and adds a triple to it describing that
+ * this data has been harvested.
+ *
+ * @async
+ * @function
+ * @param {N3.Store} store - Store to start from.
+ * @returns {N3.Store} Same store as the input (really, same reference), but
+ * with the tag triples destructively (non-functional) added to it.
+ */
+async function addHarvestingTag(store) {
+  // Get all (unique) subjects from store that have a type.
+  const subjects = store.getSubjects(ns.rdf`type`);
+  for (const sub of subjects)
+    store.addQuad(sub, ns.prov`wasGeneratedBy`, ns.app`lblod-harvesting`);
+  return store;
+}

--- a/lib/task.js
+++ b/lib/task.js
@@ -216,6 +216,7 @@ export async function getUnfinishedTasks() {
         ${rst.termToString(cts.TASK_PUBLISH_HARVESTED_TRIPLES_WITH_DELETES)}
         ${rst.termToString(cts.TASK_EXECUTE_DIFF_DELETES)}
         ${rst.termToString(cts.TASK_HARVESTING_ADD_UUIDS)}
+        ${rst.termToString(cts.TASK_HARVESTING_ADD_TAG)}
       }
       VALUES ?status {
         ${rst.termToString(cts.STATUS_BUSY)}


### PR DESCRIPTION
This PR includes a new pipeline for an `add-harvesting-tag` operation. It adds a provenance triple on every subject. This allows us to track the harvested data more easily in consuming applications.