### PR TITLE
enable query retry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM semtech/mu-javascript-template:feature-node-18
 LABEL maintainer="info@redpencil"
+ENV SUDO_QUERY_RETRY="true"


### PR DESCRIPTION
The service would fail when the virtuoso sparql endpoint was unavailable. By enabling query retry, this should be handled correctly.