### PR TITLE
Bugfix: file encoding Turtle not compatible with rest of the service

### DIFF
--- a/app.js
+++ b/app.js
@@ -153,7 +153,10 @@ async function processTask(term) {
       }
     }
   } catch (e) {
-    console.error(`Something went wrong while processing task: ${term}`, e);
+    console.error(
+      `Something went wrong while processing task: ${term.value}`,
+      e
+    );
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,7 +28,7 @@ export function storeToSparql(store) {
  * prefixes at the top to make the file more human readable.)
  */
 export function storeToTtl(store) {
-  return storeToString(store, false);
+  return storeToString(store, true);
 }
 
 /**


### PR DESCRIPTION
Normally, this service used to produce human readable (but also smaller in file size) Turtle files with prefixes and shorthand notations for triples (with ';' and ','). Since other parts of this service and stack started to implement file streaming, this is not compatible anymore. This simple hack just forces the N-Triples syntax for all files.