### PR TITLE
Use SHA hash for mirroring

### DIFF
--- a/lib/pipeline-mirroring.js
+++ b/lib/pipeline-mirroring.js
@@ -6,6 +6,7 @@ import * as grph from './graph';
 import * as uti from './utils';
 import * as rst from 'rdf-string-ttl';
 import * as sjp from 'sparqljson-parse';
+import * as crypto from 'crypto';
 import * as N3 from 'n3';
 import {
   BASES as bs,
@@ -195,10 +196,15 @@ async function renameUri(oldUri) {
   );
   const parser = new sjp.SparqlJsonParser();
   const parsedResults = parser.parseJsonResults(queryResult);
-  const newUri =
-    parsedResults.length > 0
-      ? parsedResults[0].newURI
-      : namedNode(`${RENAME_DOMAIN}${mu.uuid()}`);
+  let newUri;
+  if (parsedResults.length > 0) {
+    newUri = parsedResults[0].newURI;
+  } else {
+    const hash = crypto.createHash('sha512');
+    hash.update(oldUri.value);
+    const digest = hash.digest('base64url');
+    newUri = namedNode(`${RENAME_DOMAIN}${digest}`);
+  }
   return {
     sameAsTriple: quad(newUri, ns.owl`sameAs`, oldUri),
     newUri,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "import-with-sameas-service",
-  "version": "4.2.0",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "import-with-sameas-service",
-      "version": "4.2.0",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-with-sameas-service",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "Responsible for mirroring and publishing data and adding UUIDs.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
**[DL-5819]**

Use a hash of the old URI instead of a random new URI.

When a URI already had a mirror once, but all traces of that mirror where removed because the data is not longer in the source RDF data, this service would create a new random URI when that same subject appears again. With a hash, it would create the same URI as it did in the past.

This could be important if services and other subjects start to rely on that URI.

This issue came to light due to a recent problem with the harvested data from a vendor. On some days, half of the downloaded HTML went missing and a lot of subject got deleted. After a few days these subject reappeared, and so this service would create new random URIs because the removals where executed on the triplestore (as intended).