### PR TITLE
Feature/task folder

### DIFF
--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -4,6 +4,8 @@ import { SPARQL_PREFIXES } from '../constants';
 import { DataFactory } from 'n3';
 import { termToString } from 'rdf-string-ttl';
 import fs from 'fs/promises';
+import { join } from 'path';
+
 import { BASES as bs } from '../constants';
 import { HIGH_LOAD_DATABASE_ENDPOINT } from '../constants';
 import { NAMESPACES as ns } from '../constants';
@@ -46,10 +48,24 @@ export async function writeTtlFile(
   tempFile,
   logicalFileName,
   derivedFrom,
+  folderId = "",
+  step = "sameas"
 ) {
+  if (!folderId || folderId.trim() === '') {
+    throw new Error('folderId parameter is required and cannot be empty');
+  }
+  
+  const baseFolder = join('/share', folderId, step);
+  try {
+    await fs.mkdir(baseFolder, { recursive: true });
+  } catch (error) {
+    console.error(`Failed to create directory ${baseFolder}: ${error.message}`);
+    throw error;
+  }
+
   const phyId = literal(uuid());
   const phyFilename = literal(`${phyId.value}.ttl`);
-  const path = `/share/${phyFilename.value}`;
+  const path = join(baseFolder, phyFilename.value);
   const physicalFile = namedNode(path.replace('/share/', 'share://'));
   const loId = literal(uuid());
   const logicalFile = bs.files(loId.value);

--- a/lib/pipeline-add-harvesting-tag.js
+++ b/lib/pipeline-add-harvesting-tag.js
@@ -69,6 +69,8 @@ export async function run(task,signal = {}) {
         tempTtlFile,
         'complemented-triples.ttl',
         derivedFrom,
+        task.jobId.value,
+        'add-harvesting-tag'
       );
 
       await appendTaskResultFile(task, fileContainer, mirroredFile);

--- a/lib/pipeline-add-uuids.js
+++ b/lib/pipeline-add-uuids.js
@@ -106,6 +106,8 @@ export async function run(task, signal = {}) {
         tempTtlFile,
         'complemented-triples.ttl',
         derivedFrom,
+        task.jobId.value,
+        'add-uuid'
       );
       await appendTaskResultFile(task, fileContainer, mirroredFile);
     }

--- a/lib/pipeline-add-vendor-tag.js
+++ b/lib/pipeline-add-vendor-tag.js
@@ -75,6 +75,8 @@ export async function run(task, signal = {}) {
         tempTtlFile,
         'complemented-triples.ttl',
         derivedFrom,
+        task.jobId.value,
+        'add-vendor-tag'
       );
 
       await appendTaskResultFile(task, fileContainer, mirroredFile);

--- a/lib/pipeline-mirroring.js
+++ b/lib/pipeline-mirroring.js
@@ -82,6 +82,8 @@ export async function run(task, signal= {}) {
         tempTtlFile,
         'mirrored-triples.ttl',
         derivedFrom,
+        task.jobId.value,
+        'mirroring'
       );
       await appendTaskResultFile(task, fileContainer, mirroredFile);
     }

--- a/lib/task.js
+++ b/lib/task.js
@@ -60,7 +60,7 @@ export async function loadTask(subject) {
   const taskResponse = await querySudo(
     `
     ${SPARQL_PREFIXES}
-    SELECT DISTINCT ?graph ?task ?id ?job ?created ?modified ?status ?index ?operation ?error WHERE {
+    SELECT DISTINCT ?graph ?task ?id ?job ?jobId ?created ?modified ?status ?index ?operation ?error WHERE {
       GRAPH ?graph {
         BIND(${termToString(subject)} as ?task)
         ?task
@@ -72,6 +72,7 @@ export async function loadTask(subject) {
           adms:status ?status ;
           task:index ?index ;
           task:operation ?operation .
+        ?job mu:uuid ?jobId.
         OPTIONAL { ?task task:error ?error . }
       }
     }


### PR DESCRIPTION
every job has one folder, and every tasks has its own sub folder. this should help in many ways, instead of having millions of files in the same directory, we will now be able to group them  by jobs+tasks, which will make debugging and cleanups way simpler