### PR TITLE
restrict graph queries to the graph of the task

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -52,7 +52,7 @@ export async function getTriplesInGraph(task, defaultLimitSize = 200) {
     `
      ${SPARQL_PREFIXES}
      SELECT DISTINCT ?graph WHERE {
-        GRAPH ${task.graph} {
+        GRAPH ${termToString(task.graph)} {
           BIND(${termToString(task.task)} as ?task).
           ?task task:inputContainer ?container.
           ?container task:hasGraph ?graph.
@@ -206,7 +206,7 @@ export async function fetchFileInputContainerAndApplyBatch(
     const result = await querySudo(`
   ${SPARQL_PREFIXES}
   SELECT (count(distinct ?path) as ?count)   WHERE {
-      GRAPH  ${task.graph} {
+      GRAPH ${termToString(task.graph)} {
         BIND(${termToString(task.task)} as ?task).
         ?task task:inputContainer ?container.
         ?container task:hasGraph ?graph.
@@ -231,7 +231,7 @@ export async function fetchFileInputContainerAndApplyBatch(
     ${SPARQL_PREFIXES}
     SELECT ?path ?derivedFrom  WHERE {
       SELECT DISTINCT ?path ?derivedFrom  WHERE {
-        GRAPH ${task.graph} {
+        GRAPH ${termToString(task.graph)} {
           BIND(${termToString(task.task)} as ?task).
           ?task task:inputContainer ?container.
           ?container task:hasGraph ?graph.
@@ -267,7 +267,7 @@ export async function getDeletedTriplesInFileAndApplyByBatch(
     const result = await querySudo(`
   ${SPARQL_PREFIXES}
   SELECT (count(distinct ?path) as ?count)   WHERE {
-      GRAPH ${task.graph} {
+      GRAPH ${termToString(task.graph)} {
       ${termToString(task.task)}
         a task:Task ;
         task:inputContainer ?inputContainer .
@@ -300,7 +300,7 @@ export async function getDeletedTriplesInFileAndApplyByBatch(
     ${SPARQL_PREFIXES}
     SELECT ?path ?derivedFrom WHERE {
       SELECT DISTINCT ?path ?derivedFrom WHERE {
-        GRAPH ${task.graph} {
+        GRAPH ${termToString(task.graph)} {
           ${termToString(task.task)}
             a task:Task ;
             task:inputContainer ?inputContainer .
@@ -352,7 +352,7 @@ export async function getTriplesInFile(task) {
     `
     ${SPARQL_PREFIXES}
     SELECT DISTINCT ?path WHERE {
-      GRAPH ${task.graph} {
+      GRAPH ${termToString(task.graph)} {
         BIND(${termToString(task.task)} as ?task).
         ?task task:inputContainer ?container.
         ?container task:hasGraph ?graph.

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -52,7 +52,7 @@ export async function getTriplesInGraph(task, defaultLimitSize = 200) {
     `
      ${SPARQL_PREFIXES}
      SELECT DISTINCT ?graph WHERE {
-        GRAPH ?g {
+        GRAPH ${task.graph} {
           BIND(${termToString(task.task)} as ?task).
           ?task task:inputContainer ?container.
           ?container task:hasGraph ?graph.
@@ -206,7 +206,7 @@ export async function fetchFileInputContainerAndApplyBatch(
     const result = await querySudo(`
   ${SPARQL_PREFIXES}
   SELECT (count(distinct ?path) as ?count)   WHERE {
-      GRAPH ?g {
+      GRAPH  ${task.graph} {
         BIND(${termToString(task.task)} as ?task).
         ?task task:inputContainer ?container.
         ?container task:hasGraph ?graph.
@@ -231,7 +231,7 @@ export async function fetchFileInputContainerAndApplyBatch(
     ${SPARQL_PREFIXES}
     SELECT ?path ?derivedFrom  WHERE {
       SELECT DISTINCT ?path ?derivedFrom  WHERE {
-        GRAPH ?g {
+        GRAPH ${task.graph} {
           BIND(${termToString(task.task)} as ?task).
           ?task task:inputContainer ?container.
           ?container task:hasGraph ?graph.
@@ -267,7 +267,7 @@ export async function getDeletedTriplesInFileAndApplyByBatch(
     const result = await querySudo(`
   ${SPARQL_PREFIXES}
   SELECT (count(distinct ?path) as ?count)   WHERE {
-      GRAPH ?g {
+      GRAPH ${task.graph} {
       ${termToString(task.task)}
         a task:Task ;
         task:inputContainer ?inputContainer .
@@ -300,7 +300,7 @@ export async function getDeletedTriplesInFileAndApplyByBatch(
     ${SPARQL_PREFIXES}
     SELECT ?path ?derivedFrom WHERE {
       SELECT DISTINCT ?path ?derivedFrom WHERE {
-        GRAPH ?g {
+        GRAPH ${task.graph} {
           ${termToString(task.task)}
             a task:Task ;
             task:inputContainer ?inputContainer .
@@ -352,7 +352,7 @@ export async function getTriplesInFile(task) {
     `
     ${SPARQL_PREFIXES}
     SELECT DISTINCT ?path WHERE {
-      GRAPH ?g {
+      GRAPH ${task.graph} {
         BIND(${termToString(task.task)} as ?task).
         ?task task:inputContainer ?container.
         ?container task:hasGraph ?graph.


### PR DESCRIPTION
we have a setup with many graphs (some quite large). In our case, the simple count query 
```
  SELECT (count(distinct ?path) as ?count)   WHERE {
      GRAPH ?g {
        BIND(${termToString(task.task)} as ?task).
        ?task task:inputContainer ?container.
        ?container task:hasGraph ?graph.
        ?graph task:hasFile ?file.
        ?file prov:wasDerivedFrom ?derivedFrom.
        ?path nie:dataSource ?file.
      }
    }
```
takes quite a long time (86s) and causes jobs to fail because of timeouts. However, if we remove the graph restriction OR limit the graph to the `task.graph`, the count is instant. Is restricting these queries to the `task.graph` a reasonable thing to do? 
Would you rather we make this configurable through an environment variable or some other way?